### PR TITLE
generate_port was moved to Mojo::IOLoop::Server

### DIFF
--- a/t/auth.t
+++ b/t/auth.t
@@ -6,7 +6,7 @@ use Test::Mojo;
 
 # Make sure sockets are working
 plan skip_all => 'working sockets required for this test!'
-  unless Mojo::IOLoop->new->generate_port;    # Test server
+  unless Mojo::IOLoop->new->server->generate_port;    # Test server
 
 # Lite app
 use Mojolicious::Lite;


### PR DESCRIPTION
In Mojolicious 5.0 generate_port was removed from Mojo::IOLoop and added in Mojo::IOLoop::Server.